### PR TITLE
Feature/guidance data message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_message_files(
   LightInput.msg
   PropulsionCommand.msg
   EulerOrientations.msg
+  GuidanceData.msg
   Debug.msg
   Pwm.msg
   RovState.msg

--- a/msg/GuidanceData.msg
+++ b/msg/GuidanceData.msg
@@ -21,6 +21,3 @@ float64 z_d
 float64 v
 
 float64 t
-
-# DP, Autopilot, 
-string controller_type

--- a/msg/GuidanceData.msg
+++ b/msg/GuidanceData.msg
@@ -2,10 +2,6 @@
 # the controller system needs to function properly. All of these
 # values should be contained in this message.
 
-# Note: All the message types have been standardized for the physical
-# sizes and their derivatives. This is to prevent problems in future
-# expansion
-
 float64 u
 float64 u_d
 

--- a/msg/GuidanceData.msg
+++ b/msg/GuidanceData.msg
@@ -1,0 +1,27 @@
+# The guidance system will output multiple different values that
+# the controller system needs to function properly. All of these
+# values should be contained in this message.
+
+# Note: All the message types have been standardized for the physical
+# sizes and their derivatives. This is to prevent problems in future
+# expansion
+
+float64 u
+float64 u_d
+
+float64 u_dot
+float64 u_d_dot
+
+float64 psi
+float64 psi_d
+
+float64 r
+float64 r_d
+float64 r_d_dot
+
+float64 z
+float64 z_d
+
+float64 v
+
+float64 t

--- a/msg/GuidanceData.msg
+++ b/msg/GuidanceData.msg
@@ -25,3 +25,5 @@ float64 z_d
 float64 v
 
 float64 t
+
+string controller_type

--- a/msg/GuidanceData.msg
+++ b/msg/GuidanceData.msg
@@ -26,4 +26,5 @@ float64 v
 
 float64 t
 
+# DP, Autopilot, 
 string controller_type


### PR DESCRIPTION
Adds a new message type required to split apart the controller and guidance part of the LOS node. See https://github.com/vortexntnu/Vortex-AUV/pull/96